### PR TITLE
Typo in package name for example installation

### DIFF
--- a/sources/v3.0/include/examples/setup_examples.rst
+++ b/sources/v3.0/include/examples/setup_examples.rst
@@ -6,13 +6,13 @@
  
    ::
  
-     sudo apt-get install xilinx-alveo-u30-example   
+     sudo apt-get install xilinx-alveo-u30-examples   
  
    + RHEL and Amazon Linux 2
  
    ::
  
-     sudo yum install xilinx-alveo-u30-example   
+     sudo yum install xilinx-alveo-u30-examples   
 
 #. Configure the environment to use the |SDK|::
 


### PR DESCRIPTION
I assume the package names are the same across distros, but it's definitely an 's' on the end there for ubuntu :)